### PR TITLE
Refactoring : move exe finding from command building to main program

### DIFF
--- a/scripts/antares_test_utils.py
+++ b/scripts/antares_test_utils.py
@@ -26,9 +26,6 @@ def find_studies_in_batch_dir(batch_name):
 
     return studies
 
-def get_headers(df) -> set :
-    return set(df.columns)
-
 def remove_possibly_remaining_outputs(study_path):
     output_path = study_path / 'output'
     shutil.rmtree(output_path, ignore_errors=True)

--- a/scripts/generate_reference.py
+++ b/scripts/generate_reference.py
@@ -4,20 +4,22 @@ import antares_test_utils as antares_utils
 from run_command_building import *
 import sys
 
-# Parsing args
+# Parsing command line args
 parser = argparse.ArgumentParser()
 parser.add_argument("batch_name", help="Batch directory (containing studies)",
                     type=str)
 parser.add_argument("path_where_to_find_exe", help="Path to executable",
                     type=str)
-#  Storing args
+# Storing command line args
 args = parser.parse_args()
 batch_name = args.batch_name
 path_where_to_find_exe = Path(args.path_where_to_find_exe)
 
+# Find exe path
 if not path_where_to_find_exe.is_dir() and not path_where_to_find_exe.is_file():
     raise RuntimeError("Path where to find an executable does not exist")
-
+exe_identifier = exe_id_from_batch_name(batch_name)
+exe_path = find_exe_path(path_where_to_find_exe, exe_identifier)
 
 # Looking for studies in batch directory
 study_path_collection = antares_utils.find_studies_in_batch_dir(batch_name)
@@ -29,7 +31,7 @@ for study_path in study_path_collection:
     antares_utils.remove_possibly_remaining_outputs(study_path)
     antares_utils.enable_study_output(study_path, True)
 
-    command_to_run = make_command_to_run(path_where_to_find_exe, batch_name, study_path)
+    command_to_run = make_command_to_run(exe_path, batch_name, study_path)
     result = run_command(command_to_run)
     ret.append(result)
     print('OK' if result else 'KO')

--- a/scripts/run_command_building.py
+++ b/scripts/run_command_building.py
@@ -2,6 +2,12 @@ from pathlib import Path
 import subprocess
 import sys
 
+def exe_id_from_batch_name(batch_name):
+    exe_identifier = "solver"  # Default value
+    if batch_name == "ts-generator":
+        exe_identifier = "ts-generator"
+    return exe_identifier
+
 def find_exe_path(path_to_search_exe_in, exe_identifier):
     searched_exe = f"antares-{exe_identifier}"
     if sys.platform.startswith("win"):
@@ -14,33 +20,22 @@ def find_exe_path(path_to_search_exe_in, exe_identifier):
             return path_item.resolve()
     raise RuntimeError("Missing {searched_exe}")
 
-def make_command_to_run(path_where_to_find_exe, batch_name, study_path):
+def make_command_to_run(exe_path, batch_name, study_path):
     command_to_run = []
-    exe_path = Path()
-    exe_identifier = "solver" # Default value
-
     if batch_name == "ts-generator":
-        exe_identifier = "ts-generator"
-        exe_path = find_exe_path(path_where_to_find_exe, exe_identifier)
         print(f"Found executabled : {exe_path}")
-
         cluster_to_gen_file = open(study_path / "clustersToGen.txt", 'r')
         cluster_to_gen = cluster_to_gen_file.readline().rstrip()
         cluster_to_gen_file.close()
         command_to_run = [exe_path, cluster_to_gen, str(study_path)]
-
     else:
-        exe_path = find_exe_path(path_where_to_find_exe, exe_identifier)
         print(f"Found executabled : {exe_path}")
-
         command_to_run = [exe_path, "-i", str(study_path)]
         if batch_name == "valid-milp":
             command_to_run.append('--use-ortools')
             command_to_run.append('--ortools-solver=coin')
-
         if batch_name == "valid-named-mps":
             command_to_run.append('--named-mps-problems')
-
     return command_to_run
 
 def run_command(command):


### PR DESCRIPTION
Small refactoring : we move the path search for binary program to execute into the main program.
It allows : 
- the executable path finding is now out from the loop over studies. Inside the loop, this task was unnecessarily repeated. Now it's done once.
- it lightens the command making function, for which it's not the responsibility to search an executable path